### PR TITLE
fix(auth): resolve non-idempotent signup by validating firebase token before serializer

### DIFF
--- a/src/backend/ml_studio/accounts/services.py
+++ b/src/backend/ml_studio/accounts/services.py
@@ -1,28 +1,32 @@
-from firebase_admin import auth 
 from .models import User
 import logging
 
 logger = logging.getLogger(__name__)
 
-def Get_or_Create_User(* , id_token , serializer_data):
+def Check_User(* , uid):
     try:
-        decoded = auth.verify_id_token(id_token)
-        uid = decoded["uid"]
+        user_exists = User.objects.filter(uid = uid).exists()
+
+        if user_exists:
+            return True 
+        else:
+            return False
     except Exception as e:
-        logger.error(f"Firebase verification failed: {e}")
-        return None , False
+        logger.error(f"Database Error occurred while checking user {uid}: {e}")
+        return False
+
+
+def Create_User(* , uid , email , serializer_data):
     try:
-        user , created = User.objects.get_or_create(
+        user = User.objects.create(
                 uid = uid,
-                defaults= {
-                    "email" : decoded.get("email" , ""),
-                    **serializer_data
-                }
+                email = email ,
+                **serializer_data
                 )
         
         # TODO: Add First-Time setup logic
 
-        return user , created   
+        return user  
     except Exception as e:
         logger.error(f"Database error while saving user {uid} : {e}")
-        return None , False
+        return None

--- a/src/backend/ml_studio/accounts/views.py
+++ b/src/backend/ml_studio/accounts/views.py
@@ -1,31 +1,47 @@
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework import status 
-from .services import Get_or_Create_User
+from .services import Check_User , Create_User
 from .serializers import Signup_Serializer
+from firebase_admin import auth 
+import logging
+
 # Create your views here.
 
-class Signup_API(APIView):
-    def post(self , request):
-        auth_token = request.headers.get("Authorization")
+logger = logging.getLogger(__name__)
 
+class Signup_API(APIView):
+    def post(self , request): 
+        auth_token = request.headers.get("Authorization") 
         serializer = Signup_Serializer(data = request.data)
 
-        if serializer.is_valid(raise_exception = True):
-            if not auth_token or not auth_token.startswith("Bearer "):
+        if not auth_token or not auth_token.startswith("Bearer "):
                 return Response({"error": "Invalid or missing token. Use format 'Bearer <token>'."} , status=status.HTTP_401_UNAUTHORIZED)
             
-            id_token = auth_token.split(" ")[1]
-        
-        
-            user , created = Get_or_Create_User(id_token=id_token ,serializer_data=serializer.validated_data )
+        id_token = auth_token.split(" ")[1]
 
-            if not user :
-                return Response({"error": "Invalid token or database error"}, status=status.HTTP_401_UNAUTHORIZED)
-            
-            if created:
-                return Response({"message": "Account created successfully"}, status=status.HTTP_201_CREATED)
-            else:
-                return Response({"message": "Account already exists"}, status=status.HTTP_200_OK)
+        try:        
+            decoded = auth.verify_id_token(id_token)
+        except Exception as e:
+            logger.error(f"Firebase verification failed: {e}")
+            return Response({"error": "Invalid Firebase token"}, status=status.HTTP_401_UNAUTHORIZED)
+
+        user_exists = Check_User(uid=decoded['uid'])
+
+        # print(user_exists)
+
+        if user_exists:
+            return Response({"message": "Account already exists"}, status=status.HTTP_200_OK)
+
         else:
-            return Response({"error" : serializer.errors}, status=status.HTTP_400_BAD_REQUEST )
+            if serializer.is_valid(raise_exception = True):
+                user = Create_User( uid=decoded["uid"] , email=decoded['email'] , serializer_data=serializer.validated_data )
+
+                if not user :
+                    return Response({"error": "Failed to create user account"}, status=status.HTTP_401_UNAUTHORIZED)
+                
+                else:
+                    return Response({"message": "Account created successfully"}, status=status.HTTP_201_CREATED)
+                
+            else:
+                return Response({"error" : serializer.errors}, status=status.HTTP_400_BAD_REQUEST )


### PR DESCRIPTION
This PR restores idempotency to the `/api/signup/` endpoint by restructuring the order of operations between Firebase verification and DRF serialization.

**The Bug:**
Previously, `serializer.is_valid(raise_exception=True)` was executing before the database check. For existing users, DRF's built-in `UniqueValidator` on the `username` field was throwing a 400 Bad Request before the code could reach the `200 OK Account already exists` return block.

**The Fix:**
* Refactored `views.py` to decode the Firebase token and check for an existing `uid` first.
* Bypassed the serializer entirely for returning users, returning a safe `200 OK`.
* Updated `services.py` to cleanly handle Firebase token decoding separate from user creation.

**Resolves Issue:**
Fixes #5 