### PR TITLE
Fix Create_Org return value

### DIFF
--- a/src/backend/ml_studio/organization/services.py
+++ b/src/backend/ml_studio/organization/services.py
@@ -21,4 +21,4 @@ def Create_Org(* , name , user , type):
         role = UserRole.OWNER.value
     )
 
-    return Organization
+    return organization

--- a/src/backend/ml_studio/organization/tests.py
+++ b/src/backend/ml_studio/organization/tests.py
@@ -1,3 +1,29 @@
 from django.test import TestCase
 
-# Create your tests here.
+from accounts.models import User
+
+from .models import Membership, Organization
+from .services import Create_Org
+
+
+class CreateOrgServiceTests(TestCase):
+    def test_create_org_returns_created_organization_instance(self):
+        user = User.objects.create_user(
+            email="owner@example.com",
+            username="owner",
+            uid="firebase-owner-id",
+            password="password",
+        )
+
+        organization = Create_Org(name="Example Org", user=user, type="team")
+
+        self.assertIsInstance(organization, Organization)
+        self.assertEqual(organization.name, "Example Org")
+        self.assertEqual(organization.owner, user)
+        self.assertTrue(
+            Membership.objects.filter(
+                organization=organization,
+                user=user,
+                role="owner",
+            ).exists()
+        )


### PR DESCRIPTION
## Summary
- Return the created `organization` instance from `Create_Org` instead of the `Organization` model class.
- Add service coverage asserting the created organization is returned and the owner membership is created.

Closes #10.

## Validation
- `env PYTHONPATH=/tmp:. DJANGO_SETTINGS_MODULE=ml_studio_test_settings DJANGO_SECRET_KEY=test DEBUG=True DATABASE_URL=sqlite:///:memory: ../../../.venv/bin/python manage.py test organization`
- `../../../.venv/bin/python -m compileall -q organization`
- `git diff --check`

Note: the focused Django test was run with a temporary local settings module that uses SQLite in memory, because the default project settings require Firebase credentials and a database URL configured for SSL.