### PR TITLE
Fix login API endpoint

### DIFF
--- a/src/frontend/script.js
+++ b/src/frontend/script.js
@@ -115,7 +115,7 @@ authForm.addEventListener('submit', async (e) => {
         } else {
             userCredential = await signInWithEmailAndPassword(auth, email, password);
             
-            apiUrl = 'http://127.0.0.1:8000/auth/signup/'; // Your Login Endpoint
+            apiUrl = 'http://127.0.0.1:8000/auth/login/'; // Your Login Endpoint
             payload = {
                 email: userCredential.user.email,
                 uid: userCredential.user.uid


### PR DESCRIPTION
## Summary
- route login submissions to `/auth/login/` instead of `/auth/signup/`
- keep the signup endpoint unchanged

Fixes #13

## Validation
- `node --input-type=module --check < src/frontend/script.js`
- `python3 -m compileall -q src/backend/ml_studio`
- `git diff --check`