### PR TITLE
fix(org): return organization instance instead of class (fixes #10)

### DIFF
--- a/src/backend/ml_studio/organization/services.py
+++ b/src/backend/ml_studio/organization/services.py
@@ -21,4 +21,4 @@ def Create_Org(* , name , user , type):
         role = UserRole.OWNER.value
     )
 
-    return Organization
+    return organization


### PR DESCRIPTION
## Fix
`Create_Org` was returning the `Organization` class instead of the freshly created instance (`organization`), causing `DeferredAttribute` evaluation errors in the serializer.

## Change
`return Organization` → `return organization`

Fixes #10