### PR TITLE
fix(auth): raise AuthenticationFailed instead of returning HttpResponseForbidden

### DIFF
--- a/src/backend/ml_studio/core/authentication.py
+++ b/src/backend/ml_studio/core/authentication.py
@@ -1,6 +1,6 @@
 from accounts.models import User
 from rest_framework.authentication import BaseAuthentication
-from django.http import HttpResponseForbidden
+from rest_framework.exceptions import AuthenticationFailed
 from firebase_admin import auth
 import logging
 
@@ -11,7 +11,7 @@ class Firebase_Authentication_Middleware(BaseAuthentication):
         auth_token = request.headers.get("Authorization") 
 
         if not auth_token or not auth_token.startswith("Bearer "):
-            return HttpResponseForbidden("Invalid or missing token. Use format 'Bearer <token>'.")
+            raise AuthenticationFailed("Invalid or missing token. Use format 'Bearer <token>'.")
             
         id_token = auth_token.split(" ")[1]
 
@@ -19,7 +19,7 @@ class Firebase_Authentication_Middleware(BaseAuthentication):
             decoded = auth.verify_id_token(id_token , clock_skew_seconds=5)
         except Exception as e:
             logger.error(f"Firebase verification failed: {e}")
-            return HttpResponseForbidden("Invalid Firebase token")
+            raise AuthenticationFailed("Invalid Firebase token")
 
         try:
             user = User.objects.get(uid = decoded['uid']) 

--- a/src/backend/ml_studio/organization/views.py
+++ b/src/backend/ml_studio/organization/views.py
@@ -9,6 +9,7 @@ from .serializers import Organization_List_Serializer , Organization_Create_Seri
 from core.authentication import Firebase_Authentication_Middleware 
 import logging
 from django.http import HttpResponseForbidden
+from rest_framework.exceptions import AuthenticationFailed , PermissionDenied
 
 # Create your views here.
 
@@ -21,14 +22,14 @@ class Tenant_Base_API(APIView):
             try:
                 request.membership = Membership.objects.get(organization = request.organization , user = request.user)
             except Membership.DoesNotExist :
-                return HttpResponseForbidden('No access to this organization')
+                raise PermissionDenied('No access to this organization')
             except Exception as e :
                 logger.error(f"Error occurred while fetching organization {request.org_slug}: {e}")
                 request.membership = None
                 
             return super().initial(request,*args,**kwargs)
         else:
-            return Response({"error": "Authentication required"}, status = status.HTTP_401_UNAUTHORIZED)
+            raise AuthenticationFailed("Authentication required")
 
 class Get_Org_List_API(Tenant_Base_API):
     def get(self , request):


### PR DESCRIPTION
This PR corrects the exception-handling behavior within our Firebase authentication layer. Instead of returning a manual HttpResponseForbidden (403) when a token fails verification, the backend now explicitly raises Django REST Framework's native AuthenticationFailed exception.

Proper Status Codes: Replaced the return statement for HttpResponseForbidden with raise exceptions.AuthenticationFailed(). This forces DRF to issue a standard 401 Unauthorized status code instead of a 403 Forbidden.

Frontend Alignment: Correctly signals to the client-side app that the token session is invalid, expired, or unauthenticated, allowing the frontend to trigger clean re-authentication loops or session clearing.

Fixes #9  (Closes bug(auth): raise AuthenticationFailed instead of returning HttpResponseForbidden in Firebase Auth #9 )